### PR TITLE
Options for case conversion with numerals

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,40 @@ Version 2.\* does not work with 0.\* version of vue-resource, because it has som
 
 ## Configuration
 
-In order to restrict certain urls from converting,
-you can do it by providing `responseUrlFilter` or `requestUrlFilter` function to
-configuration object. These functions receive `url` and should return true for url
-to be processed by interceptor.
+A number of configuration options are supported, which can be set either globally or on a
+URL-by-URL basis.
+
+- __`convert` (boolean)__: Whether to convert JSON keys between cases. Defaults to `true`.
+- __`underscoreNumbers` (boolean)__: Whether to treat numbers as the start of a new word within
+  the key. For example, if true, `fooBar2` converts to `foo_bar_2`; otherwise, `fooBar2`
+  converts to `foo_bar2`. Defaults to `false`.
+- __`responseUrlFilter` (function)__: If provided, customizes behavior by URL. The function takes
+  a URL as the first argument, and should return either a boolean or an object. A boolean
+  indicates simply whether or not to make case conversions, and allows you to turn off case
+  conversion for particular APIs or URLs. An object return value should mirror the global
+  options and allows you to override `convert` and `underscoreNumbers` on a URL basis.
+  Defaults to `null`.
+- __`requestUrlFilter` (function)__: Same as `responseUrlFilter`, but for resquests.
+
+For example:
 
     Vue.use(VueResourceCaseConverter, {
+      convert: false,  // e.g., to turn off by default, and enable by URL
+      underscoreNumbers: false,
       responseUrlFilter(url) {
-        // Your custom logic
-        // For example:
-        // return url.indexOf('api') >= 0;
+        if (/api\/v2/.test(url)) {
+          return {
+            convert: true
+          };
+        }
       },
-
       requestUrlFilter(url) {
-        // Your custom logic
-      },
+        if (/api\/v2/.test(url)) {
+          return {
+            convert: true
+          };
+        }
+      }
     });
 
 ## Notes


### PR DESCRIPTION
Creates a richer options setup that allows turning conversion on/off and setting the strategy for converting case with keys that include numbers, both globally and on a case-by-case basis. 

Closes #2 